### PR TITLE
Test for setBlacklist function of BloomFilter.

### DIFF
--- a/BloomFilter-setter-test.cpp
+++ b/BloomFilter-setter-test.cpp
@@ -22,7 +22,7 @@ TEST(SettersTests, UpdateBlacklist)
     bf.setBlacklist(new_list);
     for (auto url : new_list)
     {
-        EXPECT_EQ(isBlacklisted(bf.getBlacklist(), url));
+        EXPECT_TRUE(isBlacklisted(bf.getBlacklist(), url));
     }
 }
 


### PR DESCRIPTION
Made test for setBlacklist function, in order to use load from a file in a way that will not break encapsulation.