### PR TITLE
Implement delete label by id functionality

### DIFF
--- a/src/controllers/labels.js
+++ b/src/controllers/labels.js
@@ -80,3 +80,24 @@ exports.updateLabel = (req, res) => {
     return res.status(404).json({ error: "Label not found" });
   res.status(204).send();
 };
+
+exports.deleteLabel = (req, res) => {
+  const user_id = parseInt(req.headers["user"]);
+  // Check if user ID is missing
+  if (!user_id) {
+    return res.status(400).json({ error: "Missing user ID" });
+  }
+  const label_id = parseInt(req.params.id);
+  const deleted_label = labels.deleteLabel(user_id, label_id);
+  // Check if the user ID does not exist
+  if (deleted_label === null)
+    return res.status(404).json({ error: "User not found" });
+  // Check if the label ID is missing
+  if (label_id === undefined) {
+    return res.status(400).json({ error: "Missing label ID" });
+  }
+  // If the label does not exist
+  if (!deleted_label) return res.status(404).json({ error: "Label not found" });
+
+  res.status(204).send();
+};

--- a/src/models/labels.js
+++ b/src/models/labels.js
@@ -37,9 +37,24 @@ const updateLabel = (user_id, label_id, update_name) => {
   return label;
 };
 
+const deleteLabel = (user_id, label_id) => {
+  const user = users.getUserById(user_id);
+  if (!user) return null;
+
+  // Search for the label index in the user's label array
+  const label_index = user.labels.findIndex((label) => label.id === label_id);
+  // Label does not exist return undefined
+  if (label_index === -1) return undefined;
+
+  // Remove from array by index
+  user.labels.splice(label_index, 1);
+  return true;
+};
+
 module.exports = {
   getAllLabels,
   getLabel,
   createLabel,
   updateLabel,
+  deleteLabel,
 };

--- a/src/routes/labels.js
+++ b/src/routes/labels.js
@@ -4,6 +4,10 @@ const controller = require("../controllers/labels");
 
 router.route("/").get(controller.getAllLabels).post(controller.createLabel);
 
-router.route("/:id").get(controller.getLabelById).patch(controller.updateLabel);
+router
+  .route("/:id")
+  .get(controller.getLabelById)
+  .patch(controller.updateLabel)
+  .delete(controller.deleteLabel);
 
 module.exports = router;


### PR DESCRIPTION
Added deleteLabel functionality to handle DELETE /api/labels/:id. Includes validation for missing or invalid user ID and label ID, and appropriate error responses.