### PR TITLE
add spam screen to contain all wanted logic

### DIFF
--- a/client_side/src/App.js
+++ b/client_side/src/App.js
@@ -11,10 +11,10 @@ import LabelView from "./components/Labels/LabelView";
 import StarredScreen from "./components/Star/Star";
 import ImportantScreen from "./components/Important/Important";
 import TrashScreen from "./components/Trash/Trash";
+import SpamScreen from "./components/Spam/Spam";
 
 // Temporary components
 const Sent = () => <h1>Sent</h1>;
-const Spam = () => <h1>Spam</h1>;
 
 function App() {
   return (
@@ -34,7 +34,7 @@ function App() {
           <Route index element={<Navigate to="inbox" replace />} />
           <Route path="inbox" element={<InboxScreen />} />
           <Route path="sent" element={<Sent />} />
-          <Route path="spam" element={<Spam />} />
+          <Route path="spam" element={<SpamScreen />} />
           <Route path="drafts" element={<Draft />} />
           <Route path="starred" element={<StarredScreen />} />
           <Route path="important" element={<ImportantScreen />} />

--- a/client_side/src/components/MailList/MailList.js
+++ b/client_side/src/components/MailList/MailList.js
@@ -11,6 +11,7 @@ function MailList({
   onImportantToggle,
   onDelete,
   disabledActions = false,
+  isSpamScreen = false,
 }) {
   const location = useLocation();
   // We use this component for several usages.
@@ -54,22 +55,25 @@ function MailList({
             <div className="mail-icons" onClick={(e) => e.stopPropagation()}>
               <span
                 onClick={() => {
-                  if (!disabledActions) onStarToggle(mail.id);
+                  if (!disabledActions && !isSpamScreen) onStarToggle(mail.id);
                 }}
                 aria-label="Star mail"
-                className={`star-icon ${disabledActions ? "disabled" : ""}`}
+                className={`star-icon ${
+                  disabledActions || isSpamScreen ? "disabled" : ""
+                }`}
               >
                 {starred?.has(mail.id) ? "⭐" : "☆"}
               </span>
 
               <span
                 onClick={() => {
-                  if (!disabledActions) onImportantToggle(mail.id);
+                  if (!disabledActions && !isSpamScreen)
+                    onImportantToggle(mail.id);
                 }}
                 aria-label="Important mail"
                 className={`flag-icon ${
                   important?.has(mail.id) ? "important" : ""
-                } ${disabledActions ? "disabled" : ""}`}
+                } ${disabledActions || isSpamScreen ? "disabled" : ""}`}
               >
                 {important?.has(mail.id) ? <MdFlag /> : <MdOutlineFlag />}
               </span>

--- a/client_side/src/components/Spam/Spam.js
+++ b/client_side/src/components/Spam/Spam.js
@@ -1,0 +1,117 @@
+import { useEffect, useState, useCallback } from "react";
+import { useOutletContext } from "react-router-dom";
+import "../Inbox/Inbox.css";
+import MailList from "../MailList/MailList";
+import MailDetails from "../ViewMail/ViewMail";
+import MailsControl from "../MailsControl/MailsControl";
+
+function SpamScreen() {
+  // State variables for spam data and UI state
+  const [messages, setMessages] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [error, setError] = useState("");
+  const [selectedMail, setSelectedMail] = useState(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const {
+    starredMails,
+    importantMails,
+    toggleStar,
+    toggleImportant,
+    deleteMail,
+  } = useOutletContext();
+
+  // Fetch spam data from the server for the current page
+  const fetchSpam = useCallback(
+    async (page = currentPage) => {
+      try {
+        const token = sessionStorage.getItem("jwt");
+        if (!token) return;
+
+        const res = await fetch(`/api/mails?page=${page}`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            authorization: "bearer " + token,
+            label: "Spam",
+          },
+        });
+
+        if (!res.ok) throw new Error("Failed to load spam");
+        setError("");
+        const data = await res.json();
+        setMessages(data.mails);
+        setTotalCount(data.totalCount);
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [currentPage]
+  );
+
+  // Fetch spam whenever the page changes
+  useEffect(() => {
+    fetchSpam(currentPage);
+  }, [fetchSpam, currentPage]);
+
+  // Load and show the full details of a selected mail
+  const handleMailClick = async (id) => {
+    const token = sessionStorage.getItem("jwt");
+    const res = await fetch(`/api/mails/${id}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await res.json();
+    setSelectedMail(data);
+  };
+
+  const handleDelete = async (id) => {
+    await deleteMail(id);
+    setMessages((prev) => prev.filter((mail) => mail.id !== id));
+    if (selectedMail?.id === id) setSelectedMail(null);
+  };
+
+  return (
+    <div className="inboxScreen">
+      {!selectedMail && (
+        <MailsControl
+          currentPage={currentPage}
+          totalCount={totalCount}
+          onRefresh={fetchSpam}
+          onPageChange={setCurrentPage}
+        />
+      )}
+
+      {error && <p className="error-message">{error}</p>}
+
+      {!selectedMail ? (
+        <div className="inbox-body">
+          <MailList
+            mails={messages}
+            starred={starredMails}
+            important={importantMails}
+            onSelect={handleMailClick}
+            onStarToggle={toggleStar}
+            onImportantToggle={toggleImportant}
+            onDelete={handleDelete}
+            isSpamScreen={true}
+          />
+        </div>
+      ) : (
+        <MailDetails
+          mail={selectedMail}
+          onClose={() => setSelectedMail(null)}
+          onStarToggle={toggleStar}
+          onImportantToggle={toggleImportant}
+          onDelete={handleDelete}
+          starred={starredMails}
+          important={importantMails}
+          isSpamScreen={true}
+        />
+      )}
+    </div>
+  );
+}
+
+export default SpamScreen;

--- a/client_side/src/components/ViewMail/ViewMail.css
+++ b/client_side/src/components/ViewMail/ViewMail.css
@@ -154,7 +154,8 @@
 
 .star-icon.disabled,
 .flag-icon.disabled,
-.trash-icon.disabled {
+.trash-icon.disabled,
+.spam-icon.disabled {
   opacity: 0.5;
   pointer-events: none;
   cursor: default;

--- a/client_side/src/components/ViewMail/ViewMail.js
+++ b/client_side/src/components/ViewMail/ViewMail.js
@@ -13,6 +13,7 @@ function MailDetails({
   important,
   moveToSpam,
   disabledActions = false,
+  isSpamScreen,
 }) {
   // Don't render anything if no mail is selected
   if (!mail) return null;
@@ -35,10 +36,10 @@ function MailDetails({
         <div className="mail-details-icons">
           <span
             onClick={() => {
-              if (!disabledActions) onStarToggle(mail.id);
+              if (!disabledActions && !isSpamScreen) onStarToggle(mail.id);
             }}
             className={`star-icon ${starred.has(mail.id) ? "active" : ""} ${
-              disabledActions ? "disabled" : ""
+              disabledActions || isSpamScreen ? "disabled" : ""
             }`}
             title="Star"
           >
@@ -46,11 +47,11 @@ function MailDetails({
           </span>
           <span
             onClick={() => {
-              if (!disabledActions) onImportantToggle(mail.id);
+              if (!disabledActions && !isSpamScreen) onImportantToggle(mail.id);
             }}
             className={`flag-icon ${
               important.has(mail.id) ? "important" : ""
-            } ${disabledActions ? "disabled" : ""}`}
+            } ${disabledActions || isSpamScreen ? "disabled" : ""}`}
             title="Important"
           >
             {important.has(mail.id) ? <MdFlag /> : <MdOutlineFlag />}
@@ -65,8 +66,10 @@ function MailDetails({
             <MdOutlineDelete />
           </span>
           <span
-            onClick={() => moveToSpam(mail.id)}
-            className="spam-icon"
+            onClick={() => {
+              if (!isSpamScreen) moveToSpam(mail.id);
+            }}
+            className={`spam-icon ${isSpamScreen ? "disabled" : ""}`}
             title="Mark as Spam"
           >
             <MdReport />

--- a/src/controllers/mails.js
+++ b/src/controllers/mails.js
@@ -300,9 +300,7 @@ exports.moveMailToSpam = ({ headers, params }, res) => {
     return res
       .status(returned_json.statusCode)
       .json({ error: returned_json.error });
-  const result = mails.mailToSpam(+user_id, +mail_id);
-  if (!result) {
-    return res.status(404).json({ error: "User not found" });
-  }
+
+  mails.mailToSpam(+user_id, +mail_id);
   res.sendStatus(201);
 };

--- a/src/models/mails.js
+++ b/src/models/mails.js
@@ -155,26 +155,30 @@ const deleteDraftById = (user_id, draft_id) => {
   return;
 };
 
+const getMailFromArray = (mail_id, user_array) => {
+  return user_array.find((mail) => mail.id === mail_id);
+};
+
 // Find the specific mail that the user want.
 // Return null if doesnt exist.
 const getSpecificMail = (user_id, mail_id) => {
   // Return null if this user_id does not exist.
   const get_user = users.getUserById(user_id);
-  // Check if the mail is in received or in sent.
-  // If not in both, return null.
-  const get_mail_from_received = get_user.received_mails.find(
-    (mail) => mail.id === mail_id
-  );
-  if (!get_mail_from_received) {
-    const get_mail_from_sent = get_user.sent_mails.find(
-      (mail) => mail.id === mail_id
-    );
+  if (!get_user) return null;
+  // Search the mail in all possible arrays. If not there returns null.
+  const allSources = [
+    get_user.received_mails,
+    get_user.sent_mails,
+    get_user.spam,
+    get_user.trash,
+  ];
 
-    if (!get_mail_from_sent) return null;
-
-    return get_mail_from_sent;
+  for (const source of allSources) {
+    const mail = getMailFromArray(mail_id, source);
+    if (mail) return mail;
   }
-  return get_mail_from_received;
+
+  return null;
 };
 
 // Create the wanted mails array.
@@ -227,42 +231,32 @@ const removeMailFromArray = (array, mail_id) => {
 
 // Remove mail from all labels
 const cleanupMailReferences = (user, mail_id) => {
+  const wanted_mail = getSpecificMail(user.id, mail_id);
+  removeMailFromArray(user.sent_mails, mail_id);
+  removeMailFromArray(user.received_mails, mail_id);
   removeMailFromArray(user.starred, mail_id);
   removeMailFromArray(user.important, mail_id);
   removeMailFromArray(user.trash, mail_id);
+  removeMailFromArray(user.spam, mail_id);
 
   user.labels.forEach((label) => {
     label.mails = label.mails.filter((mail) => mail.id !== mail_id);
   });
-};
-
-// Remove from inbox or sent and add to trash
-const spamOrTrashMail = (user, mail_id, mail_array) => {
-  // If mail was deleted from inbox
-  const received_index = user.received_mails.findIndex(
-    (mail) => mail.id === mail_id
-  );
-  if (received_index !== -1) {
-    const mail = user.received_mails[received_index];
-    mail_array.push(mail);
-    user.received_mails.splice(received_index, 1);
-    return;
-  }
-
-  // If mail was deleted from sent
-  const sent_index = user.sent_mails.findIndex((mail) => mail.id === mail_id);
-  if (sent_index !== -1) {
-    const mail = user.sent_mails[sent_index];
-    mail_array.push(mail);
-    user.sent_mails.splice(sent_index, 1);
-  }
+  return wanted_mail;
 };
 
 // delete mail
 const deleteSpecificMail = (user_id, mail_id) => {
   const user = users.getUserById(user_id);
-  cleanupMailReferences(user, mail_id);
-  spamOrTrashMail(user, mail_id, user.trash);
+  const wanted_mail = cleanupMailReferences(user, mail_id);
+  user.trash.push(wanted_mail);
+};
+
+// Move mail to user's spam.
+const mailToSpam = (user_id, mail_id) => {
+  const user = users.getUserById(user_id);
+  const wanted_mail = cleanupMailReferences(user, mail_id);
+  user.spam.push(wanted_mail);
 };
 
 // Empty the user's trash array
@@ -284,14 +278,6 @@ const createNewDraft = (sender, receiver, title, content) => {
   };
   sender_user.drafts.push(new_draft);
   return;
-};
-
-// Move mail to user's spam.
-const mailToSpam = (user_id, mail_id) => {
-  const user = users.getUserById(user_id);
-  cleanupMailReferences(user, mail_id);
-  spamOrTrashMail(user, mail_id, user.spam);
-  return true;
 };
 
 module.exports = {


### PR DESCRIPTION
Implemented spam screen to contain the mail list of the user's spam array.
disabled and enabled the relevant buttons (like trash, star...)
Also fixed logic in server: getSpecific mail didnt search in spam and trash which can cause errors.
After that, fixed the spam mail and delete mail functions to support all cases.